### PR TITLE
[DOCS] Add mention about benefits of covariance to FAQ

### DIFF
--- a/website/en/docs/faq/index.md
+++ b/website/en/docs/faq/index.md
@@ -143,6 +143,18 @@ const isNumber = (valueToRefine: ?number): %checks => typeof valueToRefine === '
 if (isNumber(val)) add(val, 2);
 ```
 
+### Why can't I pass Array<string> to function that takes Array<string | number>
+
+The function allows string values in an array, but in this case Flow protects the original array. In the function you would be able to push number to it which means that the type of original array would not be true. You can get rid of this by changing the argument to `$ReadOnlyArray<string | number>`. This prevents following code to push anything which makes it safe to pass stricter types to it.
+
+Example ([https://flow.org/try](https://flow.org/try/#0PTAEAEDMBsHsHcBQiSgOoEsAuALWBXLUAJwFMBDAE1gDtoBPALmQGNaBnIyGgRlAF5QACnLFijUAEEx5egB5OxDDQDmoAD4ACmvgC2AI1LEAfAEoBx0AG9EASFSjiAOgAO+djiE8ATAGZzIDSwWKQAhFIy8orKKpYu5OzspJSgyqDkNCnkkCHEoLgY7KlE8ATQWdDssKBsNFjkaToGRux2ZFj4xDTpYogAvqwcRI48EtLEsgpYSqqWggDaAOTk+iyLALoA3Mio3DwiYqaboKhyALQXbLq6pHWp3ZCweUbET+yhoTtgFz+-f-8AwFAr6gABKFGodHoZwAbi0MLRmIhapxQJBvAJhI4JAAScFUADyUPGk2iqg02j0hhM5n4lhsoFA9jAjlc7k8vm8PACwCCIXCJKi0xicQSSRSaQyWRyRnyOEKxVApXw5XSlWqtXqjSpLTapA6XR6xH6gxoqOxEQmQpmsUxSxWay2yHRB2IRyAA))
+
+### Why can't I pass { a: string} to function that takes { a: string | number }
+
+The function allows string values in an object, but in this case Flow protects the original object: In the function you would be able to mutate the object so that the property `a` would have number in it which means that the type of original object would not be true anymore. You can get rid of this by making the property covariant (read-only) `{ +a: string | number }`. This prevents following code to change the property which makes it safe to pass stricter types to the function.
+
+Example ([https://flow.org/try](https://flow.org/try/#0PTAEAEDMBsHsHcBQiSgOoEsAuALWBXLUAJwFMBDAE1gDtoBPALmQGNaBnIyGgRlAF5QAClgAjAFaNQAbwA+oclM7EMNAOahZAApr4AtqNLEtsgL4BKAQD4ZiAJCox4gHTkBoHgCYAzKBA1YLFIAQhltRVBlVQ0zUAAHcnZ2UkpQVQUaVPJIIOJQXAx2NKJ4Amgs6HZYUDYaLHJ03QMjdnsyLHxiGlAnAG5EU1YOIidSFiweKTktCKj1TVN3aQiAcmUV0FN+lDBuHhEJMYnzXr8wAB4AWmu2PT1SOrTuyFg8o2JX9mDg5FRr-4BgKBwJBoN+YAAShRqHR6JcAG4tDC0ZiIWqcUDcTzuA6SMKgADUsywKnm2iahjyZks-Bs0kQoFADjATlc7i8vn8gRCYRmShJ0QW8USyVS6XImQUOSM+RwhWKoFK+HKCkq1Vq9Ua+kprTs7U63T6AyGNAxo3Gnim8mJpJii0E0gUUjWJI2W2QWNxR08JyAA))
+
 ### I got a "Missing type annotation" error. Where does it come from? <a class="toc" id="toc-i-got-a-missing-type-annotation-error-where-does-it-come-from" href="#toc-i-got-a-missing-type-annotation-error-where-does-it-come-from"></a>
 
 Flow requires type annotations at module boundaries to make sure it can scale. To read more about that, check out our [blog post](https://medium.com/flow-type/asking-for-required-annotations-64d4f9c1edf8) about that.


### PR DESCRIPTION
Common misconception is that you should be able to pass an array of "stricter" types to an array that accepts wider range of types. This is not true, and oftentimes it causes confusion why it's not possible. It's fairly easy to fix by changing types to be read-only.

Feel free to fix potential grammar errors and enhance the explanation!
